### PR TITLE
Adding backendProtocol to ingress and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ helm install nautobot nautobot/nautobot
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+## Releases
+
+See the [Release Checklist](./docs/release-checklist.md)
+
 ## License
 
 [Apache 2.0 License](./LICENSE.txt)

--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -9,13 +9,20 @@ annotations:
       url: https://nautobot.readthedocs.io/en/stable/
     - name: Nautobot
       url: https://github.com/nautobot/nautobot
+  artifacthub.io/screenshots: |
+    - title: Main Page
+      url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot1.png
+    - title: Rack Elevation
+      url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot2.png
+    - title: Prefix hierarchy
+      url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot3.png
 apiVersion: "v2"
 appVersion: "1.1.4"
 dependencies:
   - condition: "redis.enabled"
     name: "redis"
     repository: "https://charts.bitnami.com/bitnami"
-    version: "14.X.X"
+    version: "15.X.X"
   - condition: "postgresql.enabled"
     name: "postgresql"
     repository: "https://charts.bitnami.com/bitnami"
@@ -41,4 +48,4 @@ name: "nautobot"
 sources:
   - "https://github.com/nautobot/nautobot"
   - "https://github.com/nautobot/helm-charts"
-version: "0.4.0"
+version: "0.4.1"

--- a/charts/nautobot/README.md
+++ b/charts/nautobot/README.md
@@ -1,6 +1,6 @@
 # nautobot
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
 
 Nautobot is a Network Source of Truth and Network Automation Platform.
 
@@ -280,7 +280,7 @@ $ helm delete nautobot
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 1.x.x |
 | https://charts.bitnami.com/bitnami | postgresql | 10.x.x |
-| https://charts.bitnami.com/bitnami | redis | 14.X.X |
+| https://charts.bitnami.com/bitnami | redis | 15.X.X |
 
 ## Values
 
@@ -323,6 +323,7 @@ $ helm delete nautobot
 | commonAnnotations | object | `{}` | Annotations to be applied to ALL resources created by this chart |
 | ingress.annotations | object | `{}` | Ingress annotations defined as key:value pairs, see the documentation for your specific Ingress provider for more details |
 | ingress.apiVersion | string | `nil` | Override API Version (automatically detected if not set) |
+| ingress.backendProtocol | string | `"https"` | The backend protocol to for the Ingress to communicate with the Nautobot containers, valid values: http, and https |
 | ingress.enabled | bool | `false` | Enable Ingress resource creation |
 | ingress.extraHosts | list | `[]` | The list of additional hostnames to be covered with this ingress record. Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array |
 | ingress.extraPaths | list | `[]` | Any additional arbitrary paths that may need to be added to the ingress under the main host. For example: The ALB ingress controller requires a special rule for handling SSL redirection. |

--- a/charts/nautobot/templates/configmap.yaml
+++ b/charts/nautobot/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
   NAUTOBOT_DEBUG: "False"
   {{- end }}
   NAUTOBOT_LOG_LEVEL: {{ .Values.nautobot.logLevel | quote }}
-  {{- if .Values.nautobot.metrics }}
+  {{- if or .Values.nautobot.metrics .Values.metrics.enabled }}
   NAUTOBOT_METRICS_ENABLED: "True"
   {{- else }}
   NAUTOBOT_METRICS_ENABLED: "False"

--- a/charts/nautobot/templates/ingress.yaml
+++ b/charts/nautobot/templates/ingress.yaml
@@ -25,10 +25,10 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "https" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" (default "https" .Values.ingress.backendProtocol) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name | quote }}
+    - host: {{ .hostname | quote }}
       http:
         paths:
           {{- if .extraPaths }}
@@ -38,7 +38,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "Prefix" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "https" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" (default "https" .backendProtocol) "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/charts/nautobot/values.schema.json
+++ b/charts/nautobot/values.schema.json
@@ -323,6 +323,7 @@
     "celeryWorker",
     "commonAnnotations",
     "ingress",
+    "metrics",
     "nautobot",
     "postgresql",
     "redis",
@@ -359,6 +360,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "backendProtocol",
         "enabled",
         "extraHosts",
         "extraPaths",
@@ -375,6 +377,10 @@
             "null",
             "string"
           ]
+        },
+        "backendProtocol": {
+          "type": "string",
+          "pattern": "^(http|https)$"
         },
         "enabled": {
           "type": "boolean"
@@ -401,17 +407,21 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "name": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
+              "backendProtocol": {
+                "type": "string",
+                "pattern": "^(http|https)$"
               },
               "extraPaths": {
                 "type": "array",
                 "items": {
                   "type": "object"
                 }
+              },
+              "hostname": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
               },
               "pathType": {
                 "type": "string",

--- a/charts/nautobot/values.yaml
+++ b/charts/nautobot/values.yaml
@@ -638,6 +638,9 @@ ingress:
   # -- Ingress annotations defined as key:value pairs, see the documentation for your specific Ingress provider for more details
   annotations: {}
 
+  # -- The backend protocol to for the Ingress to communicate with the Nautobot containers, valid values: http, and https
+  backendProtocol: "https"
+
   # -- Enable TLS configuration for the hostname defined at `ingress.hostname` parameter
   tls: false
 
@@ -649,10 +652,11 @@ ingress:
   extraHosts: []
   # e.g.
   # extraHosts:
-  # - name: nautobot2.local
+  # - hostname: nautobot2.local
   #   path: /
   #   pathType: "Prefix"
   #   extraPaths: []
+  #   backendProtocol: "https"
   #
 
   # -- Any additional arbitrary paths that may need to be added to the ingress under the main host.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,72 @@
+# Release Checklist
+
+This document is intended for Nautobot Helm Chart maintainers and covers the steps to perform when releasing new versions.
+
+## Versioning
+
+### Path Version Bumps (0.0.x)
+
+Minor version bumps are intended for minor bug fixes or documentation changes which will not impact the method of deployment (deployed values).
+
+### Minor Version Bumps (0.x.0)
+
+App version changes (assuming there are no significant upstream changes) and new features should come with a minor version bump, these changes can add to values.yaml but should not change the current method of deployment.
+
+### Major Version Bumps (x.0.0)
+
+Major version bumps are intended for breaking changes, and changes which will impact the current method of deployment.  Major upstream version changes should also come in a major version.
+
+### Update Requirements
+
+## All Releases
+
+### Verify CI Build Status
+
+Ensure that continuous integration testing on the `develop` branch is completing successfully.
+
+### Bump the Version
+
+Update the `version` and `appVersion` in the corresponding `Chart.yaml` file.  Be sure to set the annotation `artifacthub.io/prerelease: "true"` if the chart is a pre-release version.
+
+### Check the dependencies
+
+Check the chart dependencies in `Chart.yaml` to ensure we are using the latest.
+
+### Update the README
+
+If necessary add to the *Upgrading* section to provide instructions on migrating to the new version.
+
+### Update the annotations
+
+Artifact hub provides several [annotations](https://artifacthub.io/docs/topics/annotations/helm/) which can be added to the `Chart.yaml`.  Annotations which may change per release are:
+
+* `artifacthub.io/containsSecurityUpdates`
+* `artifacthub.io/prerelease`
+* `artifacthub.io/changes`
+
+### Update the Changelog
+
+Update the release notes for the new version and commit these changes to the `develop` branch.
+
+!!! important
+    The changelog must adhere to the [Keep a Changelog](https://keepachangelog.com/) style guide.
+
+### Submit a Pull Request
+
+Submit a pull request title **"Release vX.Y.Z"** to merge the `develop` branch into `main`. Copy the documented release notes into the pull request's body.
+
+Once CI has completed on the PR, merge it.
+
+### Create a New Release
+
+Draft a [new release](https://github.com/nautobot/nautobot/releases/new) with the following parameters.
+
+* **Tag:** Current version (e.g. `v1.0.0`)
+* **Target:** `main`
+* **Title:** Version and date (e.g. `v1.0.0 - 2021-06-01`)
+
+Copy the description from the pull request to the release.
+
+### Publish
+
+Once the release has been created the GitHub Action defined in [release-chart.yaml](../.github/workflows/release-chart.yaml) will run.  This will generate the correct packaging and publish the chart via GitHub pages in the `gh-pages` branch.


### PR DESCRIPTION
This PR:

* Adds Screenshots for ArtifactHub
* Adds a Release Checklist for releasing versions
* Adds a `backendProtocol` option for the Ingress resource to choose between http/https