### PR TITLE
Fixing #50

### DIFF
--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -18,10 +18,10 @@ annotations:
       url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/screenshot3.png
   artifacthub.io/changes: |
     - kind: fixed
-      description: Nautobot resources request/limit switched in values.yaml
+      description: Integrated Redis chart makes SSL always false
       links:
         - name: Github Issue
-          url: https://github.com/nautobot/helm-charts/issues/43
+          url: https://github.com/nautobot/helm-charts/issues/50
 apiVersion: "v2"
 appVersion: "1.1.4"
 dependencies:
@@ -54,4 +54,4 @@ name: "nautobot"
 sources:
   - "https://github.com/nautobot/nautobot"
   - "https://github.com/nautobot/helm-charts"
-version: "1.0.1"
+version: "1.0.2"

--- a/charts/nautobot/README.md
+++ b/charts/nautobot/README.md
@@ -1,6 +1,6 @@
 # nautobot
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
 
 Nautobot is a Network Source of Truth and Network Automation Platform.
 

--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -183,9 +183,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "nautobot.redis.ssl" -}}
-  {{- if eq .Values.redis.enabled true -}}
-    {{- printf "%s" "False" }}
-  {{- else if .Values.nautobot.redis.ssl -}}
+  {{- if .Values.nautobot.redis.ssl -}}
     {{- printf "%s" "True" }}
   {{- else -}}
     {{- printf "%s" "False" }}


### PR DESCRIPTION
Fixes: 50

When implementing SSL on the Redis sub-chart the `nautobot.redis.ssl` value was ignored.