### PR TITLE
added potential fix for nested object issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fixed #181 with nested root values in json schema.
+
 ### Changed
 
 * <!--- Renovate --->

--- a/charts/nautobot/values.schema.json
+++ b/charts/nautobot/values.schema.json
@@ -360,7 +360,9 @@
     }
   },
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": {
+    "type": "object"
+  },
   "required": [
     "celeryBeat",
     "celeryWorker",


### PR DESCRIPTION
Fix for issue when using the helm-chart as a subchart. Issue discussed here: https://github.com/nautobot/helm-charts/issues/181

<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #181 

<!--
    Please include a summary of the proposed changes below.
-->

Allowed aditional properties in the json schema for the root object. This seems to fullfil the issue with using this chart as a subchart, as well as still validating the schema.
