### PR TITLE
Add support for celery multi queue

### DIFF
--- a/charts/nautobot/README.md
+++ b/charts/nautobot/README.md
@@ -693,6 +693,7 @@ helm delete nautobot
 | celeryWorker.command | list | See values.yaml | Override default Nautobot Celery Worker container command (useful when using custom images) |
 | celeryWorker.containerSecurityContext | object | See values.yaml | [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) Nautobot Celery Worker Container Security Context |
 | celeryWorker.enabled | bool | `true` | Enables the Celery Worker for Nautobot |
+| celeryWorker.extraCeleryQueues | list | `[]` | Extra Celery queue to use. 1 queue = 1 Worker |
 | celeryWorker.extraEnvVars | list | `[]` | Extra Env Vars to set only on the Nautobot Celery Worker pods |
 | celeryWorker.extraEnvVarsCM | list | `[]` | List of names of existing ConfigMaps containing extra env vars for Nautobot Celery Worker pods |
 | celeryWorker.extraEnvVarsSecret | list | `[]` | List of names of existing Secrets containing extra env vars for Nautobot Celery Worker pods |
@@ -715,7 +716,7 @@ helm delete nautobot
 | celeryWorker.podSecurityContext | object | See values.yaml | [ref](ttps://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) Nautobot Celery Worker Pods Security Context |
 | celeryWorker.priorityClassName | string | `""` | Nautobot Celery Worker pods' priorityClassName |
 | celeryWorker.readinessProbe | object | See values.yaml | [ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes) Nautobot Celery Worker readiness probe |
-| celeryWorker.replicaCount | int | `2` | Number of Nautobot Celery Workers replicas to deploy |
+| celeryWorker.replicaCount | int | `2` | Number of replicas Nautobot Celery Workers listening default queue to deploy |
 | celeryWorker.resources | object | See values.yaml | [ref](http://kubernetes.io/docs/user-guide/compute-resources/) Nautobot Celery Worker resource requests and limits |
 | celeryWorker.revisionHistoryLimit | int | `3` | [ref](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) Number of old ReplicaSets to retain |
 | celeryWorker.sidecars | list | `[]` | Add additional sidecar containers to the Nautobot Celery Worker pods |

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -1,126 +1,131 @@
 ---
 {{- if .Values.celeryWorker.enabled }}
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+# Prepend the default Nautobot Celery queue
+{{- range $queue := (prepend .Values.celeryWorker.extraCeleryQueues (dict "name" "celery" "replicaCount" $.Values.celeryWorker.replicaCount)) }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" $ }}
 kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}-celery-worker
-  namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  name: {{ include "common.names.fullname" $ }}-celery-worker-{{ $queue.name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: nautobot-celery-worker
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.celeryWorker.autoscaling.enabled }}
-  replicas: {{ .Values.celeryWorker.replicaCount }}
+  {{- if not $.Values.celeryWorker.autoscaling.enabled }}
+  replicas: {{ $queue.replicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.celeryWorker.revisionHistoryLimit | int }}
-  {{- if .Values.celeryWorker.updateStrategy }}
-  strategy: {{- toYaml .Values.celeryWorker.updateStrategy | nindent 4 }}
+  revisionHistoryLimit: {{ $.Values.celeryWorker.revisionHistoryLimit | int }}
+  {{- if $.Values.celeryWorker.updateStrategy }}
+  strategy: {{- toYaml $.Values.celeryWorker.updateStrategy | nindent 4 }}
   {{- end }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" $ | nindent 6 }}
       app.kubernetes.io/component: nautobot-celery-worker
   template:
     metadata:
-      {{- if .Values.celeryWorker.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.podAnnotations "context" $) | nindent 8 }}
+      {{- if $.Values.celeryWorker.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-      labels: {{- include "common.labels.standard" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: nautobot-celery-worker
-        {{- if .Values.celeryWorker.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.podLabels "context" $) | nindent 8 }}
+        {{- if $.Values.celeryWorker.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.serviceAccount.name }}
-      serviceAccountName: {{ template "nautobot.serviceAccountName" . }}
+      {{- if $.Values.serviceAccount.name }}
+      serviceAccountName: {{ template "nautobot.serviceAccountName" $ }}
       {{- end }}
-      {{- include "nautobot.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.celeryWorker.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.hostAliases "context" $) | nindent 8 }}
+      {{- include "nautobot.imagePullSecrets" $ | nindent 6 }}
+      {{- if $.Values.celeryWorker.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.celeryWorker.affinity }}
-      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.celeryWorker.affinity "context" $) | nindent 8 }}
+      {{- if $.Values.celeryWorker.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" $.Values.celeryWorker.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.celeryWorker.podAffinityPreset "component" "nautobot-celery-worker" "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.celeryWorker.podAntiAffinityPreset "component" "nautobot-celery-worker" "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.celeryWorker.nodeAffinityPreset.type "key" .Values.celeryWorker.nodeAffinityPreset.key "values" .Values.celeryWorker.nodeAffinityPreset.values) | nindent 10 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.celeryWorker.podAffinityPreset "component" "nautobot-celery-worker" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.celeryWorker.podAntiAffinityPreset "component" "nautobot-celery-worker" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.celeryWorker.nodeAffinityPreset.type "key" $.Values.celeryWorker.nodeAffinityPreset.key "values" $.Values.celeryWorker.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.celeryWorker.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.celeryWorker.nodeSelector "context" $) | nindent 8 }}
+      {{- if $.Values.celeryWorker.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" $.Values.celeryWorker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.celeryWorker.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.tolerations "context" .) | nindent 8 }}
+      {{- if $.Values.celeryWorker.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.celeryWorker.priorityClassName }}
-      priorityClassName: {{ .Values.celeryWorker.priorityClassName | quote }}
+      {{- if $.Values.celeryWorker.priorityClassName }}
+      priorityClassName: {{ $.Values.celeryWorker.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.celeryWorker.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.celeryWorker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- if $.Values.celeryWorker.podSecurityContext.enabled }}
+      securityContext: {{- omit $.Values.celeryWorker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if .Values.celeryWorker.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.initContainers "context" $) | nindent 8 }}
+        {{- if $.Values.celeryWorker.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: nautobot-celery
-          image: {{ template "nautobot.image" . }}
-          imagePullPolicy: {{ .Values.nautobot.image.pullPolicy }}
-          {{- if .Values.celeryWorker.lifecycleHooks }}
-          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.lifecycleHooks "context" $) | nindent 12 }}
+          image: {{ template "nautobot.image" $ }}
+          imagePullPolicy: {{ $.Values.nautobot.image.pullPolicy }}
+          {{- if $.Values.celeryWorker.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.celeryWorker.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.celeryWorker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- if $.Values.celeryWorker.containerSecurityContext.enabled }}
+          securityContext: {{- omit $.Values.celeryWorker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.celeryWorker.command }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.command "context" $) | nindent 12 }}
+          {{- if $.Values.celeryWorker.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.celeryWorker.args }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.args "context" $) | nindent 12 }}
+          {{- if $.Values.celeryWorker.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.args "context" $) | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.celeryWorker.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.celeryWorker.extraEnvVars "context" $) | nindent 12 }}
+            - name: NAUTOBOT_CELERY_QUEUE_NAME
+              value: {{ $queue.name }}
+            {{- if $.Values.celeryWorker.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" $.Values.celeryWorker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ include "common.names.fullname" . }}-env
+                name: {{ include "common.names.fullname" $ }}-env
             - secretRef:
-                name: {{ include "common.names.fullname" . }}-env
-            {{- if .Values.celeryWorker.extraEnvVarsCM }}
-            {{- range .Values.celeryWorker.extraEnvVarsCM }}
+                name: {{ include "common.names.fullname" $ }}-env
+            {{- if $.Values.celeryWorker.extraEnvVarsCM }}
+            {{- range $.Values.celeryWorker.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+                name: {{ include "common.tplvalues.render" (dict "value" $ "context" $) }}
             {{- end }}
             {{- end }}
-            {{- if .Values.celeryWorker.extraEnvVarsSecret }}
-            {{- range .Values.celeryWorker.extraEnvVarsSecret }}
+            {{- if $.Values.celeryWorker.extraEnvVarsSecret }}
+            {{- range $.Values.celeryWorker.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+                name: {{ include "common.tplvalues.render" (dict "value" $ "context" $) }}
             {{- end }}
             {{- end }}
-          {{- if .Values.celeryWorker.resources }}
-          resources: {{- toYaml .Values.celeryWorker.resources | nindent 12 }}
+          {{- if $.Values.celeryWorker.resources }}
+          resources: {{- toYaml $.Values.celeryWorker.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.celeryWorker.livenessProbe.enabled }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.celeryWorker.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- if $.Values.celeryWorker.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.celeryWorker.livenessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.celeryWorker.readinessProbe.enabled }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.celeryWorker.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- if $.Values.celeryWorker.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.celeryWorker.readinessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if (include "celeryWorker.extraVolumeMounts" .) }}
-          {{- include "common.tplvalues.render" (dict "value" (include "celeryWorker.extraVolumeMounts" .) "context" $) | nindent 12 }}
+          {{- if (include "celeryWorker.extraVolumeMounts" $) }}
+          {{- include "common.tplvalues.render" (dict "value" (include "celeryWorker.extraVolumeMounts" $) "context" $) | nindent 12 }}
           {{- end }}
-        {{- if .Values.celeryWorker.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.celeryWorker.sidecars "context" $) | nindent 8 }}
+        {{- if $.Values.celeryWorker.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" $.Values.celeryWorker.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- if (include "celeryWorker.extraVolumes" .) }}
+      {{- if (include "celeryWorker.extraVolumes" $) }}
       volumes:
-        {{- include "common.tplvalues.render" (dict "value" (include "celeryWorker.extraVolumes" .) "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" (include "celeryWorker.extraVolumes" $) "context" $) | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -1,7 +1,7 @@
----
 {{- if .Values.celeryWorker.enabled }}
 # Prepend the default Nautobot Celery queue
 {{- range $queue := (prepend .Values.celeryWorker.extraCeleryQueues (dict "name" "celery" "replicaCount" $.Values.celeryWorker.replicaCount)) }}
+---
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" $ }}
 kind: Deployment
 metadata:

--- a/charts/nautobot/values.schema.json
+++ b/charts/nautobot/values.schema.json
@@ -410,6 +410,25 @@
           "properties": {
             "enabled": {
               "type": "boolean"
+            },
+            "extraCeleryQueues": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "replicaCount"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "replicaCount": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
             }
           }
         }

--- a/charts/nautobot/values.yaml
+++ b/charts/nautobot/values.yaml
@@ -469,7 +469,7 @@ rqWorker:
 celeryWorker:
   # -- Enables the Celery Worker for Nautobot
   enabled: true
-  # -- Number of Nautobot Celery Workers replicas to deploy
+  # -- Number of replicas Nautobot Celery Workers listening default queue to deploy
   replicaCount: 2
   # -- [ref](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) Number of old ReplicaSets to retain
   revisionHistoryLimit: 3
@@ -548,6 +548,8 @@ celeryWorker:
     - "worker"
     - "--loglevel"
     - "$(NAUTOBOT_LOG_LEVEL)"
+    - "--queues"
+    - "$(NAUTOBOT_CELERY_QUEUE_NAME)"
 
   # -- Override default Nautobot Celery Worker container args (useful when using custom images)
   args: []
@@ -606,6 +608,13 @@ celeryWorker:
   extraVolumes: []
   # -- List of additional volumeMounts for the Nautobot Celery Worker containers
   extraVolumeMounts: []
+  # -- Extra Celery queue to use. 1 queue = 1 Worker
+  extraCeleryQueues: []
+  # e.g
+  # extraCeleryQueues:
+  #   - name: myqueue
+  #     replicaCount: 1
+
   # -- Add additional sidecar containers to the Nautobot Celery Worker pods
   sidecars: []
   # e.g.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

I'm adding support to multi celery queue.
The goal is to have multiple worker, one for each queue.

[This doc](https://docs.nautobot.com/projects/core/en/stable/administration/celery-queues/#how-celery-task-queues-work) talk about worker environment but nothing about kubernetes deployment