### PR TITLE
allow providing passwords via secret ref

### DIFF
--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -169,107 +169,40 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 
-{{/*
-  Return the decoded database password. If postgres is enabled check the existing secret passed to postgres.
-  If not check the existing secret passed to Nautobot with key "existingSecretPasswordKey".
-
-  Pseudo Code:
-  if nautobot.db.existingSecret:
-    return value from the secret at the key nautobot.db.existingSecretPasswordKey
-  else if postgres.enabled:
-    if postgresql.auth.existingSecret:
-      return value from the secret at key postgresql.auth.secretKeys.adminPasswordKey
-    else
-      return value from postgresql.auth.password
-  else if postgresqlha.enabled:
-    if postgresqlha.postgresql.existingSecret
-      return value from the secret at key "postgresql-password"
-    else
-      return value from postgresqlha.postgresql.password
-  else if mariadb.enabled
-    if mariadb.auth.existingSecret:
-      return the value from the secret at key "mariadb-password"
-    else
-      return value from mariadb.auth.password
-  else if nautobot.db.password:
-    return value from nautobot.db.password
-  else
-    ERROR
-*/}}
-{{- define "nautobot.database.rawPassword" -}}
+{{- define "nautobot.database.passwordName" -}}
   {{- if .Values.nautobot.db.existingSecret -}}
-    {{- $password := "" -}}
-    {{- $secret := (lookup "v1" "Secret" $.Release.Namespace .Values.nautobot.db.existingSecret) -}}
-    {{- if $secret -}}
-      {{- if index $secret.data .Values.nautobot.db.existingSecretPasswordKey -}}
-        {{- $password = index $secret.data .Values.nautobot.db.existingSecretPasswordKey -}}
-      {{- else -}}
-        {{- fail (printf "Key '%s' not found in secret '%s'" .Values.nautobot.db.existingSecretPasswordKey .Values.nautobot.db.existingSecret) -}}
-      {{- end -}}
-    {{- else -}}
-      {{- fail (printf "Existing Nautobot DB secret '%s' not found!" .Values.nautobot.db.existingSecret) -}}
-    {{- end -}}
-    {{- $password | b64dec -}}
+    {{- .Values.nautobot.db.existingSecret -}}
   {{- else if eq .Values.postgresql.enabled true -}}
-      {{- if .Values.postgresql.auth.existingSecret -}}
-        {{- $password := "" -}}
-        {{- $secret := (lookup "v1" "Secret" $.Release.Namespace .Values.postgresql.auth.existingSecret) -}}
-        {{- if $secret -}}
-          {{- if index $secret.data .Values.postgresql.auth.secretKeys.adminPasswordKey -}}
-            {{- $password = index $secret.data .Values.postgresql.auth.secretKeys.adminPasswordKey -}}
-          {{- else -}}
-            {{- fail (printf "Key '%s' not found in secret %s" .Values.postgresql.auth.secretKeys.adminPasswordKey .Values.postgresql.auth.existingSecret) -}}
-          {{- end -}}
-        {{- else -}}
-          {{- fail (printf "Existing PostgreSQL secret %s not found in %s namespace!" .Values.postgresql.auth.existingSecret $.Release.Namespace) -}}
-        {{- end -}}
-        {{- $password | b64dec -}}
-      {{- else -}}
-        {{- required "A Postgres Password is required! Path: .Values.postgresql.auth.password" .Values.postgresql.auth.password -}}
-      {{- end -}}
+      {{- default (printf "%s-db-password" (include "common.names.fullname" .)) .Values.postgresql.auth.existingSecret -}}
   {{- else if eq .Values.postgresqlha.enabled true -}}
-      {{- if .Values.postgresqlha.postgresql.existingSecret -}}
-        {{- $password := "" -}}
-        {{- $secret := (lookup "v1" "Secret" $.Release.Namespace .Values.postgresqlha.postgresql.existingSecret) -}}
-        {{- if $secret -}}
-          {{- if index $secret.data "postgresql-password" -}}
-            {{- $password = index $secret.data "postgresql-password" -}}
-          {{- else -}}
-            {{- fail (printf "Key 'postgresql-password' not found in secret %s" .Values.postgresqlha.postgresql.existingSecret) -}}
-          {{- end -}}
-        {{- else -}}
-          {{- fail (printf "Existing PostgreSQL-HA secret %s not found!" .Values.postgresqlha.postgresql.existingSecret) -}}
-        {{- end -}}
-        {{- $password | b64dec -}}
-      {{- else -}}
-        {{- required "A Postgres Password is required! Path: .Values.postgresqlha.postgresql.password" .Values.postgresqlha.postgresql.password -}}
-      {{- end -}}
+    {{- if .Values.postgresql.auth.existingSecret -}}
+      {{- default (printf "%s-db-password" (include "common.names.fullname" .)) .Values.postgresqlha.auth.existingSecret -}}
+    {{- else -}}
+      {{- printf "%s-db-password" (include "common.names.fullname" .) -}}
+    {{- end -}}
   {{- else if eq .Values.mariadb.enabled true -}}
-      {{- if .Values.mariadb.auth.existingSecret -}}
-        {{- $password := "" -}}
-        {{- $secret := (lookup "v1" "Secret" $.Release.Namespace .Values.mariadb.auth.existingSecret) -}}
-        {{- if $secret -}}
-          {{- if index $secret.data "mariadb-password" -}}
-            {{- $password = index $secret.data "mariadb-password" -}}
-          {{- else -}}
-            {{- fail (printf "Key 'mariadb-password' not found in secret %s" .Values.mariadb.auth.existingSecret) -}}
-          {{- end -}}
-        {{- else -}}
-          {{- fail (printf "Existing MariaDB secret %s not found!" .Values.mariadb.auth.existingSecret) -}}
-        {{- end -}}
-        {{- $password | b64dec -}}
-      {{- else -}}
-        {{- required "A MariaDB Password is required!. Path: .Values.mariadb.auth.password" .Values.mariadb.auth.password -}}
-      {{- end -}}
-  {{- else if .Values.nautobot.db.password -}}
-    {{- .Values.nautobot.db.password -}}
+      {{- default (printf "%s-db-password" (include "common.names.fullname" .)) .Values.mariadb.auth.existingSecret -}}
   {{- else -}}
-    {{- fail (printf "You have to configure database credentials.") -}}
+    {{- printf "%s-db-password" (include "common.names.fullname" .) -}}
   {{- end -}}
 {{- end -}}
 
-{{- define "nautobot.database.encryptedPassword" -}}
-  {{- include "nautobot.database.rawPassword" . | b64enc | quote -}}
+{{- define "nautobot.database.passwordKey" -}}
+  {{- if .Values.nautobot.db.existingSecret -}}
+    {{- .Values.nautobot.db.existingSecretPasswordKey -}}
+  {{- else if eq .Values.postgresql.enabled true -}}
+    {{- if .Values.postgresql.auth.existingSecret -}}
+      {{- default "password" .Values.postgresql.auth.secretsKeys.adminPasswordKey -}}
+    {{- else -}}
+      {{- printf "password" -}}
+    {{- end -}}
+  {{- else if eq .Values.postgresqlha.enabled true -}}
+      {{- printf "postgresql-password" -}}
+  {{- else if eq .Values.mariadb.enabled true -}}
+      {{- printf "mariadb-password" -}}
+  {{- else -}}
+    {{- printf "password" -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/nautobot/templates/_secrets.tpl
+++ b/charts/nautobot/templates/_secrets.tpl
@@ -1,5 +1,4 @@
 {{- define "nautobot.secret.env" -}}
-NAUTOBOT_DB_PASSWORD: {{ include "nautobot.database.encryptedPassword" . }}
 NAUTOBOT_REDIS_PASSWORD: {{ include "nautobot.redis.encryptedPassword" . }}
 NAUTOBOT_SECRET_KEY: {{ include "nautobot.encryptedSecretKey" .}}
 {{- if .Values.nautobot.superUser.enabled }}

--- a/charts/nautobot/templates/_secrets.tpl
+++ b/charts/nautobot/templates/_secrets.tpl
@@ -1,5 +1,4 @@
 {{- define "nautobot.secret.env" -}}
-NAUTOBOT_REDIS_PASSWORD: {{ include "nautobot.redis.encryptedPassword" . }}
 NAUTOBOT_SECRET_KEY: {{ include "nautobot.encryptedSecretKey" .}}
 {{- if .Values.nautobot.superUser.enabled }}
 NAUTOBOT_SUPERUSER_API_TOKEN: {{ include "nautobot.encryptedSuperUserAPIToken" .}}

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -101,6 +101,11 @@ spec:
             {{- if $celery.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $celery.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: NAUTOBOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.database.passwordName" $ }}
+                  key: {{ include "nautobot.database.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -106,6 +106,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "nautobot.database.passwordName" $ }}
                   key: {{ include "nautobot.database.passwordKey" $ }}
+            - name: NAUTOBOT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.redis.passwordName" $ }}
+                  key: {{ include "nautobot.redis.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env

--- a/charts/nautobot/templates/job.yaml
+++ b/charts/nautobot/templates/job.yaml
@@ -71,6 +71,11 @@ spec:
             {{- if $initJob.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $initJob.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: NAUTOBOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.database.passwordName" $ }}
+                  key: {{ include "nautobot.database.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env-init

--- a/charts/nautobot/templates/job.yaml
+++ b/charts/nautobot/templates/job.yaml
@@ -76,6 +76,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "nautobot.database.passwordName" $ }}
                   key: {{ include "nautobot.database.passwordKey" $ }}
+            - name: NAUTOBOT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.redis.passwordName" $ }}
+                  key: {{ include "nautobot.redis.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env-init

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -86,6 +86,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "nautobot.database.passwordName" $ }}
                   key: {{ include "nautobot.database.passwordKey" $ }}
+            - name: NAUTOBOT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.redis.passwordName" $ }}
+                  key: {{ include "nautobot.redis.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env
@@ -149,6 +154,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "nautobot.database.passwordName" $ }}
                   key: {{ include "nautobot.database.passwordKey" $ }}
+            - name: NAUTOBOT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.redis.passwordName" $ }}
+                  key: {{ include "nautobot.redis.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env
@@ -208,6 +218,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "nautobot.database.passwordName" $ }}
                   key: {{ include "nautobot.database.passwordKey" $ }}
+            - name: NAUTOBOT_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.redis.passwordName" $ }}
+                  key: {{ include "nautobot.redis.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -81,6 +81,11 @@ spec:
             {{- if $nautobot.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $nautobot.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: NAUTOBOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.database.passwordName" $ }}
+                  key: {{ include "nautobot.database.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env
@@ -139,6 +144,11 @@ spec:
             {{- if $nautobot.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $nautobot.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: NAUTOBOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.database.passwordName" $ }}
+                  key: {{ include "nautobot.database.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env
@@ -193,6 +203,11 @@ spec:
             {{- if $nautobot.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $nautobot.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            - name: NAUTOBOT_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nautobot.database.passwordName" $ }}
+                  key: {{ include "nautobot.database.passwordKey" $ }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" $ }}-env

--- a/charts/nautobot/templates/secret.yaml
+++ b/charts/nautobot/templates/secret.yaml
@@ -16,6 +16,26 @@ type: Opaque
 data:
 {{- include "nautobot.secret.env" . | nindent 2 }}
 
+{{- if not .Values.nautobot.db.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nautobot.database.passwordName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: nautobot
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ include "nautobot.database.passwordKey" . }}: {{ .Values.nautobot.db.password | b64enc | quote }}
+{{- end }}
+
 {{- if $.Values.nautobot.singleInit -}}
 {{- $initJob := (include "nautobot.initJob" .) | mustFromJson -}}
 # Duplicate the configmaps for the init job only, they will be deleted by helm after the job succeeds.


### PR DESCRIPTION
Utilize the passwords (DB and/or Redis) supplied from the k8s secret reference(s) instead of copying it into a Nautobot specific secret. This fixes issues with "helm template", fixing #355 and allows references, fixing #283.
