### PR TITLE
Fix use of existing secrets

### DIFF
--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -192,7 +192,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- .Values.nautobot.db.existingSecretPasswordKey -}}
   {{- else if eq .Values.postgresql.enabled true -}}
     {{- if .Values.postgresql.auth.existingSecret -}}
-      {{- default "password" .Values.postgresql.auth.secretsKeys.adminPasswordKey -}}
+      {{- default "password" .Values.postgresql.auth.secretKeys.userPasswordKey -}}
     {{- else -}}
       {{- printf "password" -}}
     {{- end -}}

--- a/charts/nautobot/templates/secret.yaml
+++ b/charts/nautobot/templates/secret.yaml
@@ -16,7 +16,7 @@ type: Opaque
 data:
 {{- include "nautobot.secret.env" . | nindent 2 }}
 
-{{- if not .Values.nautobot.db.existingSecret }}
+{{- if not ( or .Values.nautobot.db.existingSecret .Values.postgresql.auth.existingSecret .Values.mariadb.auth.existingSecret ) }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #355 #356

<!--
    Please include a summary of the proposed changes below.
-->

Uses the user password instead of the admin password and removes the necessity to specify nautobot.db.existingSecret if postgresql.auth.existingSecret is already specified as described in #355 and also relating to #356.
