### PR TITLE
fix: 📝 backup-restore procedure

### DIFF
--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -5,10 +5,9 @@
 The recommended method of backing up Nautobot is simply to get a database dump from PostgreSQL:
 
 ```no-highlight
-export NAMESPACE=nautobot  # Be sure to use the correct namespace here
 export POSTGRES_SECRET_NAME=nautobot-postgresql  # If you have changed the default make sure you change it here
-export POSTGRES_PASSWORD=$(kubectl get secret --namespace $NAMESPACE $POSTGRES_SECRET_NAME -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-echo $POSTGRES_PASSWORD | kubectl exec -itn $NAMESPACE statefulset.apps/nautobot-postgresql -- pg_dump --username nautobot --clean --if-exists nautobot > backup.sql
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace <my namespace> $POSTGRES_SECRET_NAME -o jsonpath="{.data.password}" | base64 --decode)
+echo $POSTGRES_PASSWORD | kubectl exec -it --namespace <my namespace> statefulset.apps/nautobot-postgresql -- pg_dump --username nautobot --clean --if-exists nautobot > backup.sql
 ```
 
 NOTE: The name of the secret is dependent on the helm release name and may be different in your environment.
@@ -16,19 +15,19 @@ NOTE: The name of the secret is dependent on the helm release name and may be di
 Make sure to save your `NAUTOBOT_SECRET_KEY` in a safe place as well:
 
 ```no-highlight
-kubectl get secret nautobot-env -o jsonpath="{.data.NAUTOBOT_SECRET_KEY}" | base64 --decode
+kubectl get secret --namespace <my namespace> nautobot-env -o jsonpath="{.data.NAUTOBOT_SECRET_KEY}" | base64 --decode
 ```
 
 These commands specific to your deployment can be found by inspecting the notes provided after the install:
 
 ```no-highlight
-helm status nautobot
+helm status --namespace <my namespace> nautobot
 ```
 
 In addition please make sure to note ALL values used to deploy this helm chart:
 
 ```no-highlight
-helm get values -o yaml nautobot > nautobot.values.yaml
+helm get values --namespace <my namespace> -o yaml nautobot > nautobot.values.yaml
 ```
 
 As with any backup procedure, these steps should be validated in your environment before relying on them in production.
@@ -40,13 +39,13 @@ This procedure assumes the [Backup Nautobot](#backup-nautobot) procedure was fol
 Install Nautobot using the previous helm values:
 
 ```no-highlight
-helm install nautobot nautobot/nautobot -f nautobot.values.yaml
+helm install --namespace <my namespace> nautobot nautobot/nautobot -f nautobot.values.yaml
 ```
 
 Upload the backup and restore:
 
 ```no-highlight
 kubectl cp backup.sql nautobot-postgresql-0:/tmp
-export POSTGRES_PASSWORD=$(kubectl get secret --namespace nautobot nautobot-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-echo $POSTGRES_PASSWORD | kubectl exec -itn default statefulset.apps/nautobot-postgresql -- psql -U nautobot -f /tmp/backup.sql
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace <my namespace> nautobot-postgresql -o jsonpath="{.data.password}" | base64 --decode)
+echo $POSTGRES_PASSWORD | kubectl exec -it --namespace <my namespace> statefulset.apps/nautobot-postgresql -- psql -U nautobot -f /tmp/backup.sql
 ```


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #366

<!--
    Please include a summary of the proposed changes below.
-->
Changed the documentation for the backup and restore procedure to fix the missalignments. Specifically, added the `namespace` option to the relevant commands and changed the path of the postgres' secret to get the nautobot user's password that is used in `pg_dump` and not the global one. 
