### PR TITLE
fix: use correct secret name for redis password

### DIFF
--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -270,7 +270,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- else if .Values.redis.auth.existingSecret -}}
     {{- .Values.redis.auth.existingSecret -}}
   {{- else -}}
-    {{- printf "nautobot-redis" -}}
+    {{- printf "%s-redis" (include "common.names.fullname" .) -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #375

<!--
    Please include a summary of the proposed changes below.
-->
Correctly reference redis secret when using an arbitrary helm release name