### PR TITLE
fix: remove unsupported lifecycle field from default initContainer

### DIFF
--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -68,9 +68,6 @@ spec:
         - name: nautobot-init
           image: {{ include "nautobot.image" $ }}
           imagePullPolicy: {{ $nautobot.image.pullPolicy }}
-          {{- if $nautobot.lifecycleHooks }}
-          lifecycle: {{- include "common.tplvalues.render" (dict "value" $nautobot.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- if $nautobot.containerSecurityContext.enabled }}
           securityContext: {{- omit $nautobot.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
@@ -154,9 +151,6 @@ spec:
         - name: nautobot-certs
           image: {{ include "nautobot.image" $ }}
           imagePullPolicy: {{ $nautobot.image.pullPolicy }}
-          {{- if $nautobot.lifecycleHooks }}
-          lifecycle: {{- include "common.tplvalues.render" (dict "value" $nautobot.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           command:
             - "/bin/bash"
           args:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #411

This removes the `lifecycle` field from the default Nautobot initContainer, which causes an error in Helm. Lifecycle hooks are still applied to the default and other "nautobots" containers.