### PR TITLE
fix: remove uncessary metrics endpoint

### DIFF
--- a/charts/nautobot/templates/servicemonitor.yaml
+++ b/charts/nautobot/templates/servicemonitor.yaml
@@ -26,10 +26,6 @@ spec:
     {{- end }}
     {{- if (and $.Values.metrics.capacityMetrics.enabled (eq $.Values.metrics.capacityMetrics.nautobot $nautobotName)) }}
     - port: http
-      interval: {{ $.Values.metrics.serviceMonitor.interval }}
-      scrapeTimeout: {{ $.Values.metrics.serviceMonitor.scrapeTimeout }}
-      path: "/api/plugins/capacity-metrics/rq-metrics"
-    - port: http
       interval: {{ $.Values.metrics.capacityMetrics.interval }}
       scrapeTimeout: {{ $.Values.metrics.capacityMetrics.scrapeTimeout }}
       path: "/api/plugins/capacity-metrics/app-metrics"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #357

Remove `/api/plugins/capacity-metrics/rq-metrics` endpoint from Prometheus scraping
