### PR TITLE
allow additional properties in values root

### DIFF
--- a/charts/nautobot/values.schema.json
+++ b/charts/nautobot/values.schema.json
@@ -618,7 +618,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "workers",
     "celery",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #287 

<!--
    Please include a summary of the proposed changes below.
-->
By allowing additional properties in the root of the schema, anyone can use extra dependencies or pass the same `values.yaml` file to different helm charts. At the same time, we have safety in nautobot's chart specific scopes. 
Meaning:
This is now allowed:
```
extraKey:
    name: blabla
nautobot:
    image: <nautobot_image>
```
This will still produce and error and fail:
```
extraKey:
    name: blabla
nautobot:
    extraKeyNotDefinedInSchema: blabla
ingress:
   extraKeyNotDefinedInSchema: blabla
``` 
Because we have `"additionalProperties": false` under specific objects (eg nautobot, ingress). 