### PR TITLE
Fix allow multiple probe types

### DIFF
--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -271,22 +271,19 @@ spec:
           {{- if $nautobot.resources }}
           resources: {{- toYaml $nautobot.resources | nindent 12 }}
           {{- end }}
-          {{- if $nautobot.livenessProbe.enabled }}
+          {{- if and $nautobot.livenessProbe.enabled (or (hasKey $nautobot.livenessProbe "httpGet") (hasKey $nautobot.livenessProbe "tcpSocket")) }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.livenessProbe "enabled" "exec") "context" $) | nindent 12 }}
+          {{- else if $nautobot.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.livenessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $nautobot.readinessProbe.enabled }}
-          {{- if or $nautobot.readinessProbe "exec" $nautobot.readinessProbe "tcpSocket" }}
+          {{- if and $nautobot.readinessProbe.enabled (or (hasKey $nautobot.readinessProbe "exec") (hasKey $nautobot.readinessProbe "tcpSocket")) }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.readinessProbe "enabled" "httpGet") "context" $) | nindent 12 }}
-
-
-          {{- else }}
+          {{- else if $nautobot.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.readinessProbe "enabled") "context" $) | nindent 12 }}
-
-
-
           {{- end }}
-          {{- end }}
-          {{- if $nautobot.startupProbe.enabled }}
+          {{- if and $nautobot.startupProbe "exec"  (or (hasKey $nautobot.startupProbe "exec") (hasKey $nautobot.startupProbe "tcpSocket")) }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.startupProbe "enabled" "httpGet") "context" $) | nindent 12 }}
+          {{- else if $nautobot.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.startupProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -275,7 +275,16 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.livenessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
           {{- if $nautobot.readinessProbe.enabled }}
+          {{- if or $nautobot.readinessProbe "exec" $nautobot.readinessProbe "tcpSocket" }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.readinessProbe "enabled" "httpGet") "context" $) | nindent 12 }}
+
+
+          {{- else }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.readinessProbe "enabled") "context" $) | nindent 12 }}
+
+
+
+          {{- end }}
           {{- end }}
           {{- if $nautobot.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit $nautobot.startupProbe "enabled") "context" $) | nindent 12 }}


### PR DESCRIPTION
<!--
    Please include a summary of the proposed changes below.
-->
This tries to address an issue that if a user changes the type of the probes, because we don't omit the `default` ones from the values.yaml the template will have both probes. Meaning both `httpGet` and `exec` for example. This will cause the deployment to fail