### PR TITLE
Feat add auto deployment

### DIFF
--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -421,3 +421,11 @@ Get values for the init job if singleInit is true.  Default all values to the ro
 {{- $initJob = mustMergeOverwrite (deepCopy $.Values.nautobot) $.Values.initJob }}
 {{- mustToJson $initJob -}}
 {{- end }}
+
+{{/*
+Create a dict with sha256 hashes of the `configmap.yaml` & `secret.yaml` files in order to automatically
+trigger re-deploy of the Nautobot deployment when the configmap or secret changes.
+*/}}
+# {{- $file_checksums := dict }}
+# {{- $file_checksums = dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) }}
+# {{- $file_checksums = dict "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}

--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -421,11 +421,3 @@ Get values for the init job if singleInit is true.  Default all values to the ro
 {{- $initJob = mustMergeOverwrite (deepCopy $.Values.nautobot) $.Values.initJob }}
 {{- mustToJson $initJob -}}
 {{- end }}
-
-{{/*
-Create a dict with sha256 hashes of the `configmap.yaml` & `secret.yaml` files in order to automatically
-trigger re-deploy of the Nautobot deployment when the configmap or secret changes.
-*/}}
-# {{- $file_checksums := dict }}
-# {{- $file_checksums = dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) }}
-# {{- $file_checksums = dict "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $config_checksum := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
 {{- $workers := (include "nautobot.workers" .) | mustFromJson -}}
 {{- range $celeryName, $celery := $workers -}}
 {{- if $celery.enabled }}
@@ -13,7 +14,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if (or $celery.annotations $.Values.commonAnnotations) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $celery.annotations $.Values.commonAnnotations) "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $celery.annotations $.Values.commonAnnotations $config_checksum) "context" $ ) | nindent 4 }}
+  {{- else }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not $celery.autoscaling.enabled }}

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -14,9 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if (or $celery.annotations $.Values.commonAnnotations) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $celery.annotations $.Values.commonAnnotations $config_checksum) "context" $ ) | nindent 4 }}
-  {{- else }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $celery.annotations $.Values.commonAnnotations) "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not $celery.autoscaling.enabled }}
@@ -32,7 +30,9 @@ spec:
   template:
     metadata:
       {{- if $celery.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" $celery.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" (merge $celery.podAnnotations $config_checksum) "context" $) | nindent 8 }}
+      {{- else }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: nautobot-celery-{{ $celeryName }}

--- a/charts/nautobot/templates/celery-deployment.yaml
+++ b/charts/nautobot/templates/celery-deployment.yaml
@@ -1,4 +1,4 @@
-{{- $config_checksum := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
+{{- $config_checksum := dict "checksum/config-env" (include "nautobot.configMap.env" . | sha256sum ) "checksum/config" (include "nautobot.configMap.config" . | sha256sum) }}
 {{- $workers := (include "nautobot.workers" .) | mustFromJson -}}
 {{- range $celeryName, $celery := $workers -}}
 {{- if $celery.enabled }}

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -1,3 +1,7 @@
+# TODO: Move the checksum to `_helpers.tpl` and merge them into one dictionary.
+# That way we can easily merge them into all our deployments.
+# Test excessively, especially that now annotations will be by default not empty.
+{{- $checksum_config := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
 {{- $nautobots := (include "nautobot.nautobots" .) | mustFromJson -}}
 {{- range $nautobotName, $nautobot := $nautobots -}}
 {{- if $nautobot.enabled -}}
@@ -13,7 +17,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if (or $nautobot.annotations $.Values.commonAnnotations) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations) "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations $checksum_config) "context" $ ) | nindent 4 }}
+  {{- else }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $checksum_config "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not $nautobot.autoscaling.enabled }}

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -14,9 +14,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if (or $nautobot.annotations $.Values.commonAnnotations) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations $config_checksum) "context" $ ) | nindent 4 }}
-  {{- else }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations) "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not $nautobot.autoscaling.enabled }}
@@ -32,7 +30,9 @@ spec:
   template:
     metadata:
       {{- if $nautobot.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" $nautobot.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" (merge $nautobot.podAnnotations $config_checksum) "context" $) | nindent 8 }}
+      {{- else }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: nautobot-{{ $nautobotName }}

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -1,7 +1,4 @@
-# TODO: Move the checksum to `_helpers.tpl` and merge them into one dictionary.
-# That way we can easily merge them into all our deployments.
-# Test excessively, especially that now annotations will be by default not empty.
-{{- $checksum_config := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
+{{- $config_checksum := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
 {{- $nautobots := (include "nautobot.nautobots" .) | mustFromJson -}}
 {{- range $nautobotName, $nautobot := $nautobots -}}
 {{- if $nautobot.enabled -}}
@@ -17,9 +14,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if (or $nautobot.annotations $.Values.commonAnnotations) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations $checksum_config) "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" (merge $nautobot.annotations $.Values.commonAnnotations $config_checksum) "context" $ ) | nindent 4 }}
   {{- else }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $checksum_config "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $config_checksum "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if not $nautobot.autoscaling.enabled }}

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -1,4 +1,4 @@
-{{- $config_checksum := dict "checksum/config" (print $.Template.BasePath "/configmap.yaml" . | sha256sum) "checksum/secret" (print $.Template.BasePath "/secret.yaml" . | sha256sum) }}
+{{- $config_checksum := dict "checksum/config-env" (include "nautobot.configMap.env" . | sha256sum ) "checksum/config" (include "nautobot.configMap.config" . | sha256sum) }}
 {{- $nautobots := (include "nautobot.nautobots" .) | mustFromJson -}}
 {{- range $nautobotName, $nautobot := $nautobots -}}
 {{- if $nautobot.enabled -}}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #440 

<!--
    Please include a summary of the proposed changes below.
-->
For every helm release a new sha256 hash is generated for configmap and secret files. Those are added as annotations into the Pod templates of the nautobot & celery deployments. 
That way every helm release forces a rollout of all the Nautobot and Worker Pods. 


