### PR TITLE
feat: support CSI for nautobot-static volume

### DIFF
--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -31,11 +31,9 @@ annotations:
       url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/ss_plugin_chatops.png
   artifacthub.io/changes: |
     - kind: added
-      description: Added documentation for Nginx sidecar container
+      description: Added documentation for mounting nautobot-static via CSI
     - kind: changed
-      description: Upgraded Nautobot from 2.4.2 to 2.4.3
-    - kind: changed
-      description: Upgraded Bitnami common subchart from 2.29.1 to 2.30.0
+      description: Modified template to support CSI
 apiVersion: "v2"
 appVersion: "2.4.3"
 version: "2.4.5"

--- a/charts/nautobot/templates/job.yaml
+++ b/charts/nautobot/templates/job.yaml
@@ -127,6 +127,8 @@ spec:
         {{- if $.Values.nautobot.persistenceStaticFiles.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "common.names.fullname" $ }}-static
+        {{- else if and $.Values.nautobot.csiStaticFiles.enabled $.Values.nautobot.csiStaticFiles.csi }}
+          csi: {{- toYaml $.Values.nautobot.csiStaticFiles.csi | nindent 12 }}
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/docs/advanced-features/persistence.md
+++ b/docs/advanced-features/persistence.md
@@ -40,3 +40,18 @@ nautobot:
   nodeSelector:
     nautobot-storage: static
 ```
+
+Another supported option is Container Storage Interface (CSI). Following example comes from GCP:
+
+```yaml
+nautobot:
+  csiStaticFiles:
+    enabled: true
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: "your-bucket-name"
+        mountOptions: "implicit-dirs,o=noexec"
+        gcsfuseLoggingSeverity: warning
+        fileCacheCapacity: "1Gi"
+```


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: https://github.com/nautobot/helm-charts/issues/517

<!--
    Please include a summary of the proposed changes below.
-->
My idea to support CSI volume for `nautobot-static` volume.

WDYT?

Side notes with my first contribution to your helm repo:
- _(I'm not sure if I managed to properly modify `Chart.yaml` nor `CHANGELOG.md` files which states that it was moved?]_
- _I was not able to make cspell pre-commit simply work and it was failing on my end even for cleanly pulled branch of yours. I dared to use `--no-verify`_
I hope I won't cause much of extra work on your end :-)
