### PR TITLE
fix: remove http uwsgi directive when using socket

### DIFF
--- a/charts/nautobot/templates/_uwsgi.tpl
+++ b/charts/nautobot/templates/_uwsgi.tpl
@@ -3,8 +3,6 @@
 ; The IP address (typically localhost) and port that the WSGI process should listen on
 {{- if and .Values.nautobot.nginx.enabled }}
 socket = 127.0.0.1:8001
-; Listen on localhost 8003 for readiness checks
-http = 0.0.0.0:8003
 {{ else }}
 http = 0.0.0.0:8080
 {{- if not .Values.nautobot.uwsgi.disableHttps }}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #409 

<!--
    Please include a summary of the proposed changes below.
-->
Removes http directive from uwsgi if Nginx is enabled and socket is used. This is a breaking change that is already documented under Nginx advanced usage. 
