### PR TITLE
Fix Renovate configuration to allow executing post-upgrade commands

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "pre-commit": {
     "enabled": true
   },
-  "allowedPostUpgradeCommands": [
+  "allowedCommands": [
     "scripts/update_version.sh \"{{{prTitle}}}\""
   ],
   "postUpgradeTasks": {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #Nan

Renovate fails to run the post-upgrade command:

![image](https://github.com/user-attachments/assets/01193971-eaa8-4e2d-9920-b72e87ef505d)

Based on docs we must allow these commands with the `allowedCommand` directive: https://docs.renovatebot.com/configuration-options/#postupgradetasks
<!--
    Please include a summary of the proposed changes below.
-->
