### PR TITLE
Release v2.5.2

### DIFF
--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -32,15 +32,13 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Add container security context to the nautobot-cert container
+    - kind: added
+      description: Add Horizontal Pod Autoscaler (HPA) support for celery workers
     - kind: changed
-      description: Upgraded Nautobot from 2.4.5 to 2.4.6
-    - kind: fixed
-      description: Fix Helm chart dependency checks in CI
-    - kind: fixed
-      description: Fix documentation for Redis sentinel usage
+      description: Increased default timeout seconds for probes by 5 seconds
 apiVersion: "v2"
 appVersion: "2.4.6"
-version: "2.5.1"
+version: "2.5.2"
 dependencies:
   - condition: "redis.enabled"
     name: "redis"

--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -30,6 +30,8 @@ annotations:
     - title: Chatops
       url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/ss_plugin_chatops.png
   artifacthub.io/changes: |
+    - kind: added
+      description: Add container security context to the nautobot-cert container
     - kind: changed
       description: Upgraded Nautobot from 2.4.5 to 2.4.6
     - kind: fixed

--- a/charts/nautobot/README.md
+++ b/charts/nautobot/README.md
@@ -1,6 +1,6 @@
 # nautobot
 
-![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![AppVersion: 2.4.6](https://img.shields.io/badge/AppVersion-2.4.6-informational?style=flat-square)
+![Version: 2.5.2](https://img.shields.io/badge/Version-2.5.2-informational?style=flat-square) ![AppVersion: 2.4.6](https://img.shields.io/badge/AppVersion-2.4.6-informational?style=flat-square)
 
 Nautobot is a Network Source of Truth and Network Automation Platform.
 

--- a/charts/nautobot/templates/hpa.yaml
+++ b/charts/nautobot/templates/hpa.yaml
@@ -24,3 +24,29 @@ spec:
     {{- toYaml $nautobot.autoscaling.behavior | nindent 4 }}
 {{- end }}
 {{- end }}
+{{- $workers := (include "nautobot.workers" .) | mustFromJson -}}
+{{- range $celeryName, $celery := $workers -}}
+{{- if (and $celery.enabled $celery.autoscaling.enabled) }}
+---
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" $ }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" $ }}-celery-{{ $celeryName }}
+  labels:
+    app.kubernetes.io/component: nautobot-celery-{{ $celeryName }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "common.names.fullname" $ }}-celery-{{ $celeryName }}
+  minReplicas: {{ $celery.autoscaling.minReplicas | int }}
+  maxReplicas: {{ $celery.autoscaling.maxReplicas | int }}
+  metrics:
+    {{- toYaml $celery.autoscaling.metrics | nindent 4 }}
+  behavior:
+    {{- toYaml $celery.autoscaling.behavior | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -154,6 +154,9 @@ spec:
         - name: nautobot-certs
           image: {{ include "nautobot.image" $ }}
           imagePullPolicy: {{ $nautobot.image.pullPolicy }}
+          {{- if $nautobot.containerSecurityContext.enabled }}
+          securityContext: {{- omit $nautobot.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           command:
             - "/bin/bash"
           args:

--- a/charts/nautobot/values.yaml
+++ b/charts/nautobot/values.yaml
@@ -67,7 +67,7 @@ nautobot:
         - "nautobot-server health_check"
     initialDelaySeconds: 3
     periodSeconds: 15
-    timeoutSeconds: 10
+    timeoutSeconds: 15
     failureThreshold: 3
     successThreshold: 1
 
@@ -83,7 +83,7 @@ nautobot:
       port: "http"
     initialDelaySeconds: 3
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 10
     failureThreshold: 3
     successThreshold: 1
 
@@ -96,7 +96,7 @@ nautobot:
       port: "http"
     initialDelaySeconds: 3
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 10
     failureThreshold: 30
     successThreshold: 1
 

--- a/docs/release-notes/version-2.x.md
+++ b/docs/release-notes/version-2.x.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.2 - 2025-04-17
+
+### Added
+
+* [#524](https://github.com/nautobot/helm-charts/pull/524) Add container security context to the nautobot-cert container
+* [#550](https://github.com/nautobot/helm-charts/pull/550) Add Horizontal Pod Autoscaler (HPA) support for celery workers
+
+### Changed
+
+* [#551](https://github.com/nautobot/helm-charts/pull/551) Increased default timeout seconds for probes by 5 seconds
+
 ## 2.5.1 - 2025-04-04
 
 ### Changed


### PR DESCRIPTION
### Added

* [#524](https://github.com/nautobot/helm-charts/pull/524) Add container security context to the nautobot-cert container
* [#550](https://github.com/nautobot/helm-charts/pull/550) Add Horizontal Pod Autoscaler (HPA) support for celery workers

### Changed

* [#551](https://github.com/nautobot/helm-charts/pull/551) Increased default timeout seconds for probes by 5 seconds
