### PR TITLE
fix: update default nginx port for livenessProbes to not fail

### DIFF
--- a/charts/nautobot/values.yaml
+++ b/charts/nautobot/values.yaml
@@ -340,7 +340,7 @@ nautobot:
     livenessProbe:
       enabled: true
       tcpSocket:
-        port: "https"
+        port: "https-nginx"
       initialDelaySeconds: 2
       periodSeconds: 10
       timeoutSeconds: 5


### PR DESCRIPTION
The default nginx liveness probe in `values.yaml` has incorrect port name making the probe to fail. This PR tries to address that issue.