### PR TITLE
fix: Create redis secret when password is provided and chart built-in…

### DIFF
--- a/charts/nautobot/templates/secret.yaml
+++ b/charts/nautobot/templates/secret.yaml
@@ -40,6 +40,27 @@ data:
   {{ include "nautobot.database.passwordKey" . }}: {{ .Values.nautobot.db.password | b64enc | quote }}
 {{- end }}
 
+# Create secret if bitnami-packaged redis is not used, and a secret is not created
+{{- if (and .Values.nautobot.redis.password (not .Values.redis.enabled)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nautobot.redis.passwordName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: nautobot
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ include "nautobot.redis.passwordKey" . }}: {{ .Values.nautobot.redis.password | b64enc | quote }}
+{{- end }}
+
 {{- if $.Values.nautobot.singleInit -}}
 {{- $initJob := (include "nautobot.initJob" .) | mustFromJson -}}
 # Duplicate the configmaps for the init job only, they will be deleted by helm after the job succeeds.


### PR DESCRIPTION
… redis is not in use

Current behavior:
- Current deployment assumes redis secret existence, which is created only if built-in redis is in use: https://github.com/bitnami/charts/blob/redis/18.19.4/bitnami/redis/templates/secret.yaml
- If used redis is external, and the password is provided in nautobot values, an error occurs during deployment declaring non-existence of redis secret. 

<!--
    Please include a summary of the proposed changes below.
-->

There should be a secret created (like a db secret) for redis if it is not created by redis bitnami chart