### PR TITLE
fix: Remove unsupported bitnami ingress helpers

### DIFF
--- a/charts/nautobot/templates/ingress.yaml
+++ b/charts/nautobot/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" (merge .Values.ingress.annotations .Values.commonAnnotations) "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- if $nautobot.enabled }}
           {{- range $ingressPath := $nautobot.ingressPaths }}
           - path: {{if $nautobot.staticFilesOnly }}"/static"{{ else }}{{ $ingressPath | quote }}{{ end }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" $) $nautobotName) "servicePort" (default "https" $.Values.ingress.backendProtocol) "context" $)  | nindent 14 }}
           {{- end }}
           {{- end }}
@@ -46,9 +44,7 @@ spec:
           {{- if $nautobot.enabled }}
           {{- range $ingressPath := $nautobot.ingressPaths }}
           - path: {{if $nautobot.staticFilesOnly }}"/static"{{ else }}{{ $ingressPath | quote }}{{ end }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" $) $nautobotName) "servicePort" (default "https" $.Values.ingress.backendProtocol) "context" $)  | nindent 14 }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Removes usage of the following bitnami/common helpers:
- common.ingress.supportsIngressClassname
- common.ingress.supportsPathType

Without this patch, deploying this nautobot helm chart can sometimes fail.

per bitnami/charts#33496

<!--
    Thank you for your interest in contributing to the Nautobot Helm Chart! Please note
    that our contribution policy recommends (but does not require) that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.

    Please make sure this PR updates the CHANGELOG.md at the root of the repo and the corresponding
    Chart.yaml artifacthub.io/changes annotation.
-->

### Fixes: #596

Bitnami has removed certain helpers and depending on the options passed to this helm chart, installation/upgrade can fail. See #596 for details.
