### PR TITLE
chore: prep for release 2.5.6

### DIFF
--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: nautobot
-      image: ghcr.io/nautobot/nautobot:2.4.14-py3.11
+      image: ghcr.io/nautobot/nautobot:2.4.17-py3.11
   artifacthub.io/links: |
     - name: Nautobot Documentation
       url: https://docs.nautobot.com/
@@ -31,16 +31,14 @@ annotations:
       url: https://raw.githubusercontent.com/nautobot/nautobot/develop/nautobot/docs/media/ss_plugin_chatops.png
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed nginx config to support https2 using proper syntax
+      description: Fixed ingress by removing bitnami unsupported helpers
     - kind: changed
-      description: Changed to use bitnamilegacy docker images
+      description: Upgraded Nautobot from 2.4.14 to 2.4.17
     - kind: changed
-      description: Upgraded Nautobot from 2.4.11 to 2.4.14
-    - kind: changed
-      description: Upgraded Bitnami common subchart from 2.30.2 to 2.31.3
+      description: Upgraded minor version of bitnamilegacy docker images
 apiVersion: "v2"
-appVersion: "2.4.14"
-version: "2.5.5"
+appVersion: "2.4.17"
+version: "2.5.6"
 dependencies:
   - condition: "redis.enabled"
     name: "redis"

--- a/charts/nautobot/README.md
+++ b/charts/nautobot/README.md
@@ -1,6 +1,6 @@
 # nautobot
 
-![Version: 2.5.5](https://img.shields.io/badge/Version-2.5.5-informational?style=flat-square) ![AppVersion: 2.4.14](https://img.shields.io/badge/AppVersion-2.4.14-informational?style=flat-square)
+![Version: 2.5.6](https://img.shields.io/badge/Version-2.5.6-informational?style=flat-square) ![AppVersion: 2.4.17](https://img.shields.io/badge/AppVersion-2.4.17-informational?style=flat-square)
 
 Nautobot is a Network Source of Truth and Network Automation Platform.
 

--- a/docs/release-notes/version-2.x.md
+++ b/docs/release-notes/version-2.x.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.6 - 2025-09-08
+
+### Fixed
+
+* [#597](https://github.com/nautobot/helm-charts/pull/597) Fix ingress by removing bitnami unsupported helpers
+
+### Changed
+
+* Upgraded Nautobot from 2.4.14 to 2.4.17
+* Upgraded minor version of bitnamilegacy docker images
+
 ## 2.5.5 - 2025-08-06
 
 ### Fixed


### PR DESCRIPTION
Preparation to release `2.5.6` version
