### PR TITLE
Update renovate configuration to allow running script update_version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,11 @@
     "enabled": true
   },
   "allowedPostUpgradeCommands": [
-    "scripts/update_version.sh \"{{{prTitle}}}\""
+    "scripts/update_version.sh \".*\""
   ],
   "postUpgradeTasks": {
     "commands": [
-      "scripts/update_version.sh \"{{{prTitle}}}\""
+      "scripts/update_version.sh \"Update {{{depName}}} to {{{newVersion}}}\""
     ],
     "fileFilters": [
       "**/README.md",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "pre-commit": {
     "enabled": true
   },
-  "allowedPostUpgradeCommands": [
+  "allowedCommands": [
     "scripts/update_version.sh \".*\""
   ],
   "postUpgradeTasks": {


### PR DESCRIPTION
Automatically updating the versions is currently not working. Check https://github.com/nautobot/helm-charts/pull/612#issuecomment-3260008144

Based on https://github.com/renovatebot/renovate/discussions/31081 the `prTitle` is no longer available.

Also:
* https://docs.renovatebot.com/configuration-options/#prtitle
* https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands