### PR TITLE
Remove running a script from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,19 +6,6 @@
   "pre-commit": {
     "enabled": true
   },
-  "allowedCommands": [
-    "scripts/update_version.sh \".*\""
-  ],
-  "postUpgradeTasks": {
-    "commands": [
-      "scripts/update_version.sh \"Update {{{depName}}} to {{{newVersion}}}\""
-    ],
-    "fileFilters": [
-      "**/README.md",
-      "**/Chart.yaml",
-      "CHANGELOG.md"
-    ]
-  },
   "packageRules": [
     {
       "description": [


### PR DESCRIPTION
Running post-deployment commands is only supported for self-hosted Renovate runners.

This PR removes the command. This must be implemented as a task in a GitHub action.

For reference:
https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands

<img width="1166" height="413" alt="image" src="https://github.com/user-attachments/assets/64a72abc-5f9c-407d-9af8-610f8a8e044a" />

<img width="1091" height="265" alt="image" src="https://github.com/user-attachments/assets/c847bf7c-1149-4c1c-97b1-59ca9e3b80e4" />
