### PR TITLE
fix: helm lint for extra objects

### DIFF
--- a/charts/nautobot/templates/extra-objects.yaml
+++ b/charts/nautobot/templates/extra-objects.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.extraObjects }}
 ---
   {{- if typeIs "string" . }}
-    {{- tpl . $ }}
+    {{- tpl (. | nindent 0) $ }}
   {{- else }}
     {{- tpl (. | toYaml | nindent 0) $ }}
   {{- end }}


### PR DESCRIPTION
`helm lint` is failing if you render string objects as extra objects. This fixes that issue because it removes the extra chars