### PR TITLE
Remove the lookup function

### DIFF
--- a/charts/nautobot/templates/_helpers.tpl
+++ b/charts/nautobot/templates/_helpers.tpl
@@ -165,13 +165,6 @@ The following scenarios are supported to define the NAUTOBOT_DB_USER env var:
 value: {{ .Values.postgresql.auth.username | quote }}
   {{- else -}}
     {{- if .Values.nautobot.db.existingSecret -}}
-      {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.nautobot.db.existingSecret) -}}
-      {{- if not $secretObj }}
-        {{ fail (printf "The secret %q does not exist" .Values.nautobot.db.existingSecret) }}
-      {{- end }}
-      {{- if not (hasKey $secretObj.data .Values.nautobot.db.existingSecretUsernameKey) }}
-        {{ fail (printf "USERNAME ERROR: The secret %q does not contain the key %q" .Values.nautobot.db.existingSecret .Values.nautobot.db.existingSecretUsernameKey) }}
-      {{- end }}
 valueFrom:
   secretKeyRef:
     name: {{ .Values.nautobot.db.existingSecret | quote}}
@@ -219,13 +212,6 @@ valueFrom:
     {{- end -}}
   {{- else -}}
     {{- if .Values.nautobot.db.existingSecret -}}
-      {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.nautobot.db.existingSecret) -}}
-      {{- if not $secretObj }}
-        {{ fail (printf "The secret %q does not exist" .Values.nautobot.db.existingSecret) }}
-      {{- end }}
-      {{- if not (hasKey $secretObj.data .Values.nautobot.db.existingSecretPasswordKey) }}
-        {{ fail (printf "PASSWORDS ERROR: The secret %q does not contain the key %q" .Values.nautobot.db.existingSecret .Values.nautobot.db.existingSecretPasswordKey) }}
-      {{- end }}
 valueFrom:
   secretKeyRef:
     name: {{ .Values.nautobot.db.existingSecret | quote }}

--- a/charts/nautobot/tests/nautobot_deployment_test.yaml
+++ b/charts/nautobot/tests/nautobot_deployment_test.yaml
@@ -51,23 +51,6 @@ set:
   serviceAccount:
     create: true
     name: "test-nautobot-sa"
-# Mock existing secrets for testing
-kubernetesProvider:
-  scheme:
-    "v1/Secret":
-      gvr:
-        version: "v1"
-        resource: "secrets"
-      namespaced: true
-  objects:
-    - kind: "Secret"
-      apiVersion: "v1"
-      metadata:
-        name: "test-external-postgresql"
-        namespace: "test"
-      data:
-        mydbusername: "bXluYXV0b2JvdHVzZXI="
-        mydbpassword: "bXlkYnBhc3N3b3Jk"
 release:
   name: "test"
   namespace: "test"


### PR DESCRIPTION
Fixes #679 

The ArgoCD deployment fails with the error:

```
Unable to create application: application spec for nautobot-helm-lookup-test is invalid: InvalidSpecError: Unable to 
generate manifests in : rpc error: code = Unknown desc = failed to execute helm template command: failed to get 
command args to log: `helm template . --name-template nautobot-helm-lookup-test --namespace nautobot-helm-test 
--kube-version 1.33 --set nautobot.db.existingSecret=nautobot-database-credentials --set 
nautobot.db.existingSecretPasswordKey=dbpassword --set nautobot.db.existingSecretUsernameKey=dbusername <api 
versions removed> --include-crds` failed exit status 1: Error: execution error at (nautobot/templates/nautobot-
deployment.yaml:85:18): The secret "nautobot-database-credentials" does not exist Use --debug flag to render out 
invalid YAML
```

The `lookup` function causes more issues than it benefits, so this PR removes it.
