### PR TITLE
Fix spacing for the uwsgi.ini template

### DIFF
--- a/charts/nautobot/templates/_uwsgi.tpl
+++ b/charts/nautobot/templates/_uwsgi.tpl
@@ -13,7 +13,7 @@ https = 0.0.0.0:8443,/opt/certs/nautobot.crt,/opt/certs/nautobot.key
 ; Enable HTTPS support with self-signed TLS certs
 https = 0.0.0.0:8443,/opt/nautobot/nautobot.crt,/opt/nautobot/nautobot.key
 {{- end }}
-{{- end -}}
+{{ end }}
 {{ end }}
 
 {{- if .Values.metrics.uwsgiExporter.enabled -}}


### PR DESCRIPTION
Fixes #691 

The template is not rendered correctly when the uwsgi exporter is enabled:

```
--set metrics.uwsgiExporter.enabled=true
```

This PR fixes the issue.