### PR TITLE
fix: add missing namespace to HPA metadata

### DIFF
--- a/charts/nautobot/templates/hpa.yaml
+++ b/charts/nautobot/templates/hpa.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ include "common.capabilities.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" $ }}-{{ $nautobotName }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: nautobot-{{ $nautobotName }}
     {{- if $.Values.commonLabels }}
@@ -32,6 +33,7 @@ apiVersion: {{ include "common.capabilities.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" $ }}-celery-{{ $celeryName }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: nautobot-celery-{{ $celeryName }}
     {{- if $.Values.commonLabels }}


### PR DESCRIPTION
The HPA template was missing `namespace` in the metadata for both nautobot and celery worker HorizontalPodAutoscalers, unlike every other template which sets `namespace: {{ $.Release.Namespace | quote }}`.

