### PR TITLE
UWSGI Exporter fix

### DIFF
--- a/charts/nautobot/Chart.yaml
+++ b/charts/nautobot/Chart.yaml
@@ -38,6 +38,8 @@ annotations:
       description: Fixed allowing configuration of scrape protocols for Service Monitor.
     - kind: fixed
       description: Fixed removing pdb config for the Celery Beat if enabled for workers.
+    - kind: fixed
+      description: Fixed uwsgi-exporter sidecar dialing localhost; now uses 127.0.0.1 to match the IPv4-only stats listener and avoid IPv6 resolution failures.
 apiVersion: "v2"
 appVersion: "3.0"
 version: "3.1.1"

--- a/charts/nautobot/templates/nautobot-deployment.yaml
+++ b/charts/nautobot/templates/nautobot-deployment.yaml
@@ -427,7 +427,7 @@ spec:
           securityContext: {{- omit $.Values.metrics.uwsgiExporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           args:
-            - "--stats.uri=http://localhost:1717"
+            - "--stats.uri=http://127.0.0.1:1717"
           {{- if $.Values.metrics.uwsgiExporter.resources }}
           resources: {{- toYaml $.Values.metrics.uwsgiExporter.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Fixes: UWSGI-Exporter metrics

  ### Summary
  Switch the hard-coded `uwsgi-exporter` sidecar arg from `--stats.uri=http://localhost:1717` to `--stats.uri=http://127.0.0.1:1717`.

  ### Problem
  uWSGI's stats server (configured by `_uwsgi.tpl`) binds IPv4-only on `127.0.0.1:1717`. The exporter is launched with `localhost`, and on container images where the resolver returns `::1` first,
  every scrape fails:

      caller=exporter.go:192 level=error msg="Scrape failed"
      error="error querying uwsgi stats: Get \"http://localhost:1717\":
      dial tcp [::1]:1717: connect: connection refused"

  Verified inside an affected pod:
  - `/proc/net/tcp` shows `0100007F:06B5` (127.0.0.1:1717) in LISTEN.
  - `/proc/net/tcp6` has no listener on port 1717.
  - nautobot logs confirm: `*** Stats server enabled on 127.0.0.1:1717 fd: N ***`.

  ### Fix
  Dial the IPv4 literal directly, matching the address uWSGI already binds in the chart's own `_uwsgi.tpl`. No new values, no behavior change for users who weren't already broken.

  ### Test
  Patched the rendered Deployment via a Flux postRenderer in production — exporter immediately stopped logging scrape errors, `uwsgi_*` metrics appeared on `/metrics`, and the matching Grafana
  dashboard populated as expected.